### PR TITLE
Allow caller to pass in call config

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 # Setup
-source .env
+set -o allexport; source .env; set +o allexport
+
 npm run netlify-config-redirect
 
 # Configure exit trap

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(ts|js|tsx)$': 'ts-jest',
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import './env';
-import DailyIframe from '@daily-co/daily-js';
 
 // These imports ensure relevant assets are bundled
 // with the rest of the build
@@ -10,62 +9,7 @@ import './assets/favicon.ico';
 import './assets/github.png';
 import './assets/new-tab-icon.png';
 import { createRoom } from './create';
-
-function getContainer(): HTMLDivElement {
-  return <HTMLDivElement>document.getElementById('container');
-}
-
-function updateJoinedElement(roomURL: string = '') {
-  const inCall = document.getElementById('inCall');
-  if (!inCall) {
-    throw new Error('failed to find inCall element in DOM');
-  }
-  const c = 'hidden';
-  if (roomURL) {
-    inCall.innerText = roomURL;
-    inCall.classList.remove(c);
-    return;
-  }
-  inCall.innerText = '';
-  inCall.classList.add(c);
-}
-
-// Join the video call
-function joinCall(roomURL: string) {
-  const container = getContainer();
-
-  // Update the following as desired to optimize for perf tests
-  const callFrame = DailyIframe.createFrame(container, {
-    showLeaveButton: true,
-    activeSpeakerMode: false,
-    layoutConfig: {
-      grid: {
-        maxTilesPerPage: 2,
-      },
-    },
-    iframeStyle: {
-      position: 'fixed',
-      width: 'calc(100% - 1rem)',
-      height: 'calc(100% - 5rem)',
-    },
-  });
-
-  // Set up a couple of handlers to make it simpler to detect
-  // when we're in from TestRTC
-  callFrame
-    .on('joined-meeting', () => {
-      updateJoinedElement(roomURL);
-    })
-    .on('left-meeting', () => {
-      updateJoinedElement();
-    });
-
-  // Join!
-  callFrame.join({
-    url: roomURL,
-    userName: 'Robot',
-  });
-}
+import { joinCall } from './join';
 
 // When the DOM is loaded, init room join
 window.addEventListener('DOMContentLoaded', () => {
@@ -74,14 +18,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // If room URL is provided, just join the call
   if (params.roomURL) {
-    joinCall(params.roomURL);
+    joinCall(params.roomURL, params.callConfig);
     return;
   }
 
   // If room URL is not provided, create a room
   createRoom(params.roomParams)
     .then((url) => {
-      joinCall(url);
+      joinCall(url, params.callConfig);
     })
     .catch((e) => {
       throw new Error(`failed to create a Daily room for the test: ${e}`);

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,0 +1,97 @@
+import DailyIframe, { DailyCallOptions } from '@daily-co/daily-js';
+
+function getContainer(): HTMLDivElement {
+  return <HTMLDivElement>document.getElementById('container');
+}
+
+function updateJoinedElement(roomURL: string = '') {
+  const inCall = document.getElementById('inCall');
+  if (!inCall) {
+    throw new Error('failed to find inCall element in DOM');
+  }
+  const c = 'hidden';
+  if (roomURL) {
+    inCall.innerText = roomURL;
+    inCall.classList.remove(c);
+    return;
+  }
+  inCall.innerText = '';
+  inCall.classList.add(c);
+}
+
+// parseCallConfig parses the given JSON-format call object config,
+// validates that it consists of valid DailyCallOptions fields,
+// and returns a DailyCallOptions object.
+function parseCallConfig(callConfig: string): DailyCallOptions {
+  try {
+    const parsedConfig = JSON.parse(callConfig);
+    const callOptions = <DailyCallOptions>parsedConfig;
+
+    // Verify that every given key is a valid Daily call option
+    const parsedConfigKeys = Object.keys(parsedConfig);
+    
+    for (let i = 0; i < parsedConfigKeys.length; i += 1) {
+      const k = parsedConfigKeys[i];
+      // If the given key is not in our call options instance,
+      // throw an error. The caller misconfigured their request.
+      if (!(k in callOptions)) {
+        throw new Error(`invalid call option key provided: ${k}`);
+      }
+    }
+    return callOptions;
+  } catch (e) {
+    throw new Error(
+      `failed to parse supplied call config. Did you supply valid JSON?: ${e}`
+    );
+  }
+}
+
+// buildCallOptions takes a call config JSON string
+// and returns an associated instance of DailyCallOptions
+function buildCallOptions(callConfig: string): DailyCallOptions {
+  const callOptions = parseCallConfig(callConfig);
+
+  const defaultCallOptions = {
+    showLeaveButton: true,
+    activeSpeakerMode: false,
+    layoutConfig: {
+      grid: {
+        maxTilesPerPage: 2,
+      },
+    },
+    iframeStyle: {
+      position: 'fixed',
+      width: 'calc(100% - 1rem)',
+      height: 'calc(100% - 5rem)',
+    },
+  };
+
+  return { ...defaultCallOptions, ...callOptions };
+}
+
+// joinCall joins the given video call with the provided call configuration
+export function joinCall(roomURL: string, callConfig: string = '{}') {
+  console.log('callConfig:', callConfig);
+  const container = getContainer();
+
+  const callOptions = buildCallOptions(callConfig);
+  console.log('final call options:', callOptions);
+
+  const callFrame = DailyIframe.createFrame(container, callOptions);
+
+  // Set up a couple of handlers to make it simpler to detect
+  // when we're in from TestRTC
+  callFrame
+    .on('joined-meeting', () => {
+      updateJoinedElement(roomURL);
+    })
+    .on('left-meeting', () => {
+      updateJoinedElement();
+    });
+
+  // Join!
+  callFrame.join({
+    url: roomURL,
+    userName: 'Robot',
+  });
+}

--- a/src/tests/join.test.ts
+++ b/src/tests/join.test.ts
@@ -1,0 +1,53 @@
+import * as join from '../join';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="container"></div>';
+});
+
+describe('Valid config call option building tests', () => {
+  test('No extra call config provided', () => {
+    const gotFrame = join.testExports.createCallFrame('{}');
+    expect(gotFrame).toBeTruthy();
+  });
+
+  test('Basic valid call config provided', () => {
+    const callConfig = `{"showLeaveButton": false}`;
+    const callOptions = join.testExports.buildCallOptions(callConfig);
+    expect(callOptions.showLeaveButton).toBe(false);
+    const gotFrame = join.testExports.createCallFrame(callConfig);
+    expect(gotFrame).toBeTruthy();
+  });
+
+  test('Nested valid call config provided', () => {
+    const callConfig = `{"layoutConfig": {
+            	    "grid": {
+            	      "minTilesPerPage": 3,
+            	      "maxTilesPerPage": 36
+            	    }
+            	  }}`;
+    const callOptions = join.testExports.buildCallOptions(callConfig);
+
+    const gotGrid = callOptions.layoutConfig?.grid;
+    expect(gotGrid?.minTilesPerPage).toBe(3);
+    expect(gotGrid?.maxTilesPerPage).toBe(36);
+
+    const gotFrame = join.testExports.createCallFrame(callConfig);
+    expect(gotFrame).toBeTruthy();
+  });
+});
+
+describe('Invalid config call option building tests', () => {
+  test('Invalid JSON call config provided', () => {
+    const callConfig = `{"hi:34}`;
+    expect(() => {
+      join.testExports.createCallFrame(callConfig);
+    }).toThrowError();
+  });
+
+  test('Nested invalid call config provided', () => {
+    const callConfig = `{"layoutConfigs": {"grid": {"minTilesPerPage": 3,"maxTilesPerPage": 36}}}`;
+    expect(() => {
+      join.testExports.createCallFrame(callConfig);
+    }).toThrowError();
+  });
+});


### PR DESCRIPTION
This PR adds support for the `callConfig` query parameter, to enable the user to set their own Daily iframe properties when joining a Daily call.

Example usage:

```
https://deploy-preview-4--daily-testrtc.netlify.app/?callConfig={"showLeaveButton":false}
```